### PR TITLE
better use of Markdown formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,41 +1,46 @@
 libswift
 ========
 
-The multiparty transport protocol
+The multiparty transport protocol.
 
 ## Description ##
-    Libswift (aka BitTorrent at the transport layer).
-    Differently from TCP, the protocol does not use the ordered data stream
-    abstraction. Effectively, it splits a file into 1KB packets and sends
-    them around. The secret sauce is Merkle hash trees and binmaps.
+Libswift (aka BitTorrent at the transport layer). Differently from TCP,
+the protocol does not use the ordered data stream abstraction.
+Effectively, it splits a file into 1KB packets and sends them around.
+The secret sauce is Merkle hash trees and binmaps.
  
-    Requires libevent-2.0.17 or higher.
+Requires libevent-2.0.17 or higher.
+
+See [doc/index.html][1] for marketing stuff, ideas and rants,
+[doc/draft-ietf-ppsp-peer-protocol-00.txt][2] for the drafr protocol specification,
+and `*.cpp` files for the actual code.
+
+[1]: http://htmlpreview.github.com/?https://github.com/libswift/libswift/blob/master/doc/index.html
+[2]: https://raw.github.com/libswift/libswift/master/doc/draft-ietf-ppsp-peer-protocol-00.txt
 
 ## Usage ##
-    see doc/index.html for marketing stuff, ideas and rants
-    doc/draft-ietf-ppsp-grishchenko-swift.txt for protocol draft spec
-    *.cpp for the actual code
-    swift.cpp is the main exec file; may run as e.g.
+
+`swift.cpp` is the main exec file; it may be run as e.g.
     
-        ./swift -t node300.das2.ewi.tudelft.nl:20000 -h \
-        d1502706c46779d361a1d562a10da0a45c4c40e5 -f \
-        trailer.ogg
+    $ ./swift -t node300.das2.ewi.tudelft.nl:20000 -h \
+    d1502706c46779d361a1d562a10da0a45c4c40e5 -f \
+    trailer.ogg
         
-    ...to retrieve video and save it to a file.
+...to retrieve video and save it to a file.
 
-    Alternatively, you might play with the HTTP gateway, the preliminary
-    version. First, run the seeder-tracker: 
+Alternatively, you might play with the HTTP gateway, the preliminary
+version. First, run the seeder-tracker: 
 
-        $ ./swift -f ~/Downloads/big_buck_bunny_480p_stereo.ogg -l 0.0.0.0:20000
-        Root hash: 7c462ad1d980ba44ab4b819e29004eb0bf6e6d5f
+    $ ./swift -f ~/Downloads/big_buck_bunny_480p_stereo.ogg -l 0.0.0.0:20000
+    Root hash: 7c462ad1d980ba44ab4b819e29004eb0bf6e6d5f
 
-    ...then you may try running the swift-HTTP gateway...
+...then you may try running the swift-HTTP gateway...
 
-        $ ./swift -t 127.0.0.1:20000 -g 0.0.0.0:8080 -w
+    $ ./swift -t 127.0.0.1:20000 -g 0.0.0.0:8080 -w
 
-    ...and finally you may point your browser at the gateway...
+...and finally you may point your browser at the gateway...
 
-        http://127.0.0.1:8080/7c462ad1d980ba44ab4b819e29004eb0bf6e6d5f
-
-    If you use an HTML5 browser (Chrome preferred), you are likely to see
-    the bunny trailer at this point...
+    http://127.0.0.1:8080/7c462ad1d980ba44ab4b819e29004eb0bf6e6d5f
+        
+If you use an HTML5 browser (Chrome preferred),
+you are likely to see the bunny trailer at this point...

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ libswift
 The multiparty transport protocol.
 
 ## Description ##
-Libswift (aka BitTorrent at the transport layer). Differently from TCP,
-the protocol does not use the ordered data stream abstraction.
+This is Libswift (aka BitTorrent at the transport layer).
+Differently from TCP, the protocol does not use the ordered data stream abstraction.
 Effectively, it splits a file into 1KB packets and sends them around.
 The secret sauce is Merkle hash trees and binmaps.
  


### PR DESCRIPTION
- better line wrapping for code editing
- include links to referred doc files
- move non-usage info to the description section
- de-indent text so that it doesn't show up as code
- a couple other minor tweaks
