### PR TITLE
Bug fix: switch back to sending data (slowstart) as soon as new data is ...

### DIFF
--- a/send_control.cpp
+++ b/send_control.cpp
@@ -28,7 +28,14 @@ const char* Channel::SEND_CONTROL_MODES[] = {"keepalive", "pingpong",
 tint    Channel::NextSendTime () {
     TimeoutDataOut(); // precaution to know free cwnd
     switch (send_control_) {
-        case KEEP_ALIVE_CONTROL: return KeepAliveNextSendTime();
+        case KEEP_ALIVE_CONTROL:
+            if (data_out_.size() > 0)
+            {
+                // There is data to be sent. Switch to slowstart to deliver it asap
+                SwitchSendControl(SLOW_START_CONTROL);
+                return SlowStartNextSendTime();
+            }
+            return KeepAliveNextSendTime();
         case PING_PONG_CONTROL:  return PingPongNextSendTime();
         case SLOW_START_CONTROL: return SlowStartNextSendTime();
         case AIMD_CONTROL:       return AimdNextSendTime();


### PR DESCRIPTION
...available

Peer switches to keepalive mode (sendrecv.cpp) when no more data available to send. Under some conditions (we've seen this on Wifi) the sending peer gets stuck in keepalive mode for several seconds. This commit solves the problem.
