### PR TITLE
Fix Windows path problem that causes swift segfault

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -87,6 +87,8 @@ if sys.platform == "win32":
     libs = ['ws2_32', 'libevent', 'Advapi32'] 
     if WITHOPENSSL:
         libs.append('libeay32')
+    if DEBUG:
+        libs.append('Dbghelp')
 
     # Somehow linker can't find uuid.lib
     WINSDK_70 = u"C:\\Program Files\\Microsoft SDKs\\Windows\\v7.0"

--- a/compat.cpp
+++ b/compat.cpp
@@ -26,6 +26,13 @@
 #include <iostream>
 #include <sstream>
 
+#ifdef DEBUG
+# ifdef _WIN32
+#  include <windows.h>
+#  include <Dbghelp.h>
+# endif // _WIN32
+#endif // DEBUG
+
 
 namespace swift
 {
@@ -36,6 +43,36 @@ namespace swift
 // Arno, 2013-10-16: For improved usec_time()
     LARGE_INTEGER epochcounter;
 #endif
+
+    void print_backtrace(void)
+    {
+#ifdef DEBUG
+# ifdef _WIN32
+        unsigned int   i;
+        void         * stack[100];
+        unsigned short frames;
+        SYMBOL_INFO  * symbol;
+        HANDLE         process;
+
+        process = GetCurrentProcess();
+
+        SymInitialize( process, NULL, TRUE );
+
+        frames               = CaptureStackBackTrace(0, 100, stack, NULL);
+        symbol               = (SYMBOL_INFO *)calloc(sizeof(SYMBOL_INFO) + 256 * sizeof(char), 1);
+        symbol->MaxNameLen   = 255;
+        symbol->SizeOfStruct = sizeof(SYMBOL_INFO);
+
+        for (i = 0; i < frames; i++) {
+            SymFromAddr(process, (DWORD64)(stack[ i ]), 0, symbol);
+            fprintf(stderr, "%i: %s - 0x%0X\n", frames - i - 1, symbol->Name, symbol->Address);
+        }
+        fflush(stderr);
+
+        free(symbol);
+# endif // _WIN32
+#endif // DEBUG
+    }
 
     int64_t file_size(int fd)
     {
@@ -81,6 +118,9 @@ namespace swift
         int e = WSAGetLastError();
         if (e)
             fprintf(stderr,"windows error #%" PRIu32 "\n",e);
+#endif
+#ifdef DEBUG
+        print_backtrace();
 #endif
     }
 

--- a/compat.h
+++ b/compat.h
@@ -189,6 +189,8 @@ namespace swift
      * which are converted when used to UTF-16 (Windows) or the locale (UNIX).
      */
 
+    void print_backtrace(void);
+
 // Return UTF-16 representation of utf8str. Caller must free returned value.
     wchar_t* utf8to16(std::string utf8str);
     std::string utf16to8(wchar_t* utf16str);

--- a/content.cpp
+++ b/content.cpp
@@ -32,7 +32,7 @@ uint64_t ContentTransfer::cleancounter = 0;
 #define TRACKER_RETRY_INTERVAL_MAX  (1800*TINT_SEC) // 30 minutes
 
 ContentTransfer::ContentTransfer(transfer_t ttype) :  ttype_(ttype),
-    swarm_id_(), mychannels_(), callbacks_(), picker_(NULL),
+    swarm_id_(), mychannels_(), callbacks_(), picker_(NULL), hashtree_(NULL),
     speedupcount_(0), speeddwcount_(0), trackerurl_(),
     tracker_retry_interval_(TRACKER_RETRY_INTERVAL_START),
     tracker_retry_time_(NOW),
@@ -50,8 +50,10 @@ ContentTransfer::~ContentTransfer()
 {
     dprintf("%s F%d content deconstructor\n",tintstr(),td_);
     CloseChannels(mychannels_,true);
-    if (storage_ != NULL)
+    if (storage_ != NULL) {
         delete storage_;
+        storage_ = NULL;
+    }
 
     if (ext_tracker_client_ != NULL) {
         delete ext_tracker_client_;

--- a/storage.cpp
+++ b/storage.cpp
@@ -377,6 +377,10 @@ int Storage::ParseSpec(StorageFile *sf)
             ospath += Storage::spec2ospn(specpath);
 
             StorageFile *sf = new StorageFile(specpath,offset,fsize,ospath);
+            if (!sf->IsOperational()) {
+                SetBroken();
+                return -1;
+            }
             sfs_.push_back(sf);
             offset += fsize;
         }

--- a/storage.cpp
+++ b/storage.cpp
@@ -83,6 +83,11 @@ Storage::Storage(std::string ospathname, std::string destdir, int td, uint64_t l
         dprintf("%s %s storage: Found multifile-spec, will seed it.\n", tintstr(), roothashhex().c_str());
 
         StorageFile *sf = new StorageFile(MULTIFILE_PATHNAME,0,fsize,filename);
+        if (!sf->IsOperational()) {
+            print_error("storage: multi-file spec file is not operational");
+            SetBroken();
+            return;
+        }
         sfs_.push_back(sf);
         if (ParseSpec(sf) < 0) {
             print_error("storage: error parsing multi-file spec");


### PR DESCRIPTION
Windows has a 260 MAX_PATH limit. If swift tries to operate on a file that exceeds this path length, it will fail and raise a segmentation fault. This PR fixes this problem.
