### PR TITLE
Update sendrecv.cpp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 # Remove NDEBUG define to trigger asserts
-CPPFLAGS+=-O2 -I. -DNDEBUG -Wall -Wno-sign-compare -Wno-unused -g -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -DOPENSSL
+CPPFLAGS+=-O2 -std=gnu++11 -I. -DNDEBUG -Wall -Wno-sign-compare -Wno-unused -g -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -DOPENSSL
 LDFLAGS+=-levent -lstdc++ -lssl -lcrypto
 
 uname_S := $(shell sh -c 'uname -s 2>/dev/null || echo not')

--- a/sendrecv.cpp
+++ b/sendrecv.cpp
@@ -580,7 +580,9 @@ void Channel::AddHint(struct evbuffer *evb)
     else
         dip = total/count;
 
-    int first_plan_pck = max((tint)1, plan_for / dip);
+    int first_plan_pck = (tint)1;
+    if (dip != 0) 
+      first_plan_pck = max((tint)1, plan_for / dip);
 
     // Riccardo, 2012-04-04: Actually allowed is max minus what we already asked for
     int queue_allowed_hints = max(0,first_plan_pck-(int)hint_out_size_);


### PR DESCRIPTION
Got division by zero in line 583 so I made this change. My change sets first_plan_pck to 1 if dip = 0  and this seems to be what the original code sets as maximum if result is > 1. 
