### PR TITLE
Dockerfile initial version.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM gcc
+
+COPY . /usr/src/swift
+WORKDIR /usr/src/swift
+
+RUN make
+
+ENTRYPOINT [ "./swift" ]


### PR DESCRIPTION
Add Dockerfile to enable image building.
Using the official GCC image, latest tag. More info at https://hub.docker.com/_/gcc/

Just adding files, setting working dir and running `make`. 

Build:

```
$ docker build -t libswift .
```

Run:

```
$ docker run -dit --name swift libswift [options...]
```

FYI, there's a still quicker to test, already built image on my Docker Hub. Test it by running:

```
$ docker run --rm -it --name swift -p 20000:20000 pataquets/libswift:devel [options...]
```

Using `--rm` instead of `-d` makes the container not go background. `CTRL+C`'ing it should stop it, but `swift` seems to ignore `SIGTERM`. Run `docker stop swift` from another terminal. Example exposes container's port 20000 to host. Add more `-p` switches as needed.

Optional improvement to come:
- Create an 'official', based on your repo, automated build at Docker Hub for the image: https://docs.docker.com/docker-hub/builds/ . Just requires a free Docker Hub account and a following a quick 'Create automated build' process. I've already created an org named libswift, also with an AB, but based on my Gh repo. I will be happy to transfer it to maintainer/packager.
